### PR TITLE
Add ability to hide mappings from WhichKey display

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ let g:which_key_map['w'] = {
 
 <p align="center"><img width="800px" src="https://raw.githubusercontent.com/liuchengxu/img/master/vim-which-key/spc-w.png"></p>
 
+If you wish to hide a mapping from the menu set it's description to `'which_key_ignore'`. Useful for instance, to hide a list of <leader>[1-9] window swapping mappings. For example the below mapping will not be shown in the menu.
+```vim
+nnoremap <leader>1 :1wincmd w<CR>
+let g:which_key_map.1 = 'which_key_ignore'
+```
+
 #### Example
 
 Refer to [space-vim](https://github.com/liuchengxu/space-vim/blob/master/core/autoload/spacevim/map/leader.vim) for more detailed example.

--- a/autoload/which_key/util.vim
+++ b/autoload/which_key/util.vim
@@ -18,7 +18,7 @@ function! which_key#util#calc_layout(mappings) abort
   let smap = filter(copy(a:mappings), 'v:key !=# "name"')
   let layout.n_items = len(smap)
   let length = values(map(smap,
-        \ 'strdisplaywidth(v:key.'.
+        \ 'strdisplaywidth(get(s:displaynames, toupper(v:key), v:key).'.
         \ '(type(v:val) == type({}) ? v:val["name"] : v:val[1]))'))
 
   let maxlength = max(length) + g:which_key_hspace

--- a/autoload/which_key/util.vim
+++ b/autoload/which_key/util.vim
@@ -15,7 +15,7 @@ let s:displaynames = {
 
 function! which_key#util#calc_layout(mappings) abort
   let layout = {}
-  let smap = filter(copy(a:mappings), 'v:key !=# "name"')
+  let smap = filter(copy(a:mappings), 'v:key !=# "name" && !(type(v:val) == type([]) && v:val[1] == "which_key_ignore")')
   let layout.n_items = len(smap)
   let length = values(map(smap,
         \ 'strdisplaywidth(get(s:displaynames, toupper(v:key), v:key).'.
@@ -56,6 +56,9 @@ function! which_key#util#create_string(layout, mappings) abort
   for k in smap
     let key = get(s:displaynames, toupper(k), k)
     let desc = type(mappings[k]) == type({}) ? mappings[k].name : mappings[k][1]
+    if desc == 'which_key_ignore'
+      continue
+    endif
     let item = s:combine(key, desc)
 
     let crow = get(rows, row, [])


### PR DESCRIPTION
Allows setting the description to `'which_key_ignore'` in order for it to not be displayed in the menu. This is a useful feature, for instance to hide window number mappings which are otherwise repetitive and make clutter:
```vim
nnoremap <leader>1 :1wincmd w<CR>
let g:which_key_map.1 = 'which_key_ignore'
nnoremap <leader>2 :2wincmd w<CR>
let g:which_key_map.2 = 'which_key_ignore'
...
```
These would be hidden.

The second commit also means that the layout is correctly calculated when keys are matched in the s:displaynames dict, before if hspace was set to a lower value and SPC was inserted the string would not be laid out correctly.