### PR TITLE
Completely disable numbers in which_key window

### DIFF
--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -47,6 +47,7 @@ function! s:open() abort
   endif
 
   setlocal filetype=which_key
+  setlocal nonumber norelativenumber
 
   let s:winnr = winnr()
 


### PR DESCRIPTION
In my case there is some option or plugin that enables `number` and `relativenumber` in which_key window. So I have to un-`setlocal` them explicitly.

Maybe there is better approach, I'm not that proficient with VimL and there is probably a better way to do this.