### PR TITLE
fix bug: recognize ':' successfully.

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -241,7 +241,7 @@ function! s:execute(cmd) abort
       let Cmd = s:join('call', 'feedkeys("\'.Cmd.'")')
     elseif Cmd =~? '.(*)$' && match(Cmd, '\<call\>') == -1
       let Cmd = s:join('call', Cmd)
-    elseif Cmd =~ '^:' || Cmd =~? '^call feedkeys(.*)$'
+    elseif exists(':'.Cmd)  || Cmd =~ '^:' || Cmd =~? '^call feedkeys(.*)$'
       let Cmd = Cmd
     else
       let Cmd = s:join('call', 'feedkeys("'.Cmd.'")')

--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -241,7 +241,7 @@ function! s:execute(cmd) abort
       let Cmd = s:join('call', 'feedkeys("\'.Cmd.'")')
     elseif Cmd =~? '.(*)$' && match(Cmd, '\<call\>') == -1
       let Cmd = s:join('call', Cmd)
-    elseif exists(':'.Cmd) || Cmd =~? '^call feedkeys(.*)$'
+    elseif Cmd =~ '^:' || Cmd =~? '^call feedkeys(.*)$'
       let Cmd = Cmd
     else
       let Cmd = s:join('call', 'feedkeys("'.Cmd.'")')


### PR DESCRIPTION
The original command exist(':'.Cmd) is not valid.