### PR TITLE
New Feature: specify the prefix by 'key'

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -8,6 +8,12 @@ function! which_key#register(prefix, dict) abort
   call extend(s:desc, {key:val})
 endfunction
 
+fun! s:get_real_key(k)
+    let key = a:k
+    let d = eval(s:desc[key])
+    return type(d) == v:t_dict ? get(d, 'key', key): key
+endf
+
 function! which_key#start(vis, bang, prefix) " {{{
   let s:vis = a:vis ? 'gv' : ''
   let s:count = v:count != 0 ? v:count : ''
@@ -24,7 +30,7 @@ function! which_key#start(vis, bang, prefix) " {{{
   if !has_key(s:cache, key) || g:which_key_run_map_on_popup
     " First run
     let s:cache[key] = {}
-    call which_key#map#parse(key, s:cache[key], s:vis ==# 'gv' ? 1 : 0)
+    call which_key#map#parse(s:get_real_key(key), s:cache[key], s:vis ==# 'gv' ? 1 : 0)
   endif
 
   " s:runtime is a dictionary combining the native key mapping dictionary
@@ -94,7 +100,7 @@ function! s:merge(target, native) " {{{
       endif
 
     " Support add a description to an existing map without dual definition
-    elseif type(v) == s:TYPE.string && k != 'name'
+    elseif type(v) == s:TYPE.string && k != 'name' && k != 'key'
 
       " <Tab> <C-I>
       if k == '<Tab>' && has_key(native, '<C-I>')


### PR DESCRIPTION
这个PR的改进是：通过'key'这个关键字指定某个弹出菜单的prefix key。

搞这个的目的主要是用于同一个按键在不同的buffer下使用不同的菜单；比如这是我在Defx类型的buffer下的配置：
```vim
let maplocalleader = ','

nn <buffer><silent><localleader>s :call defxhelper#search_text()<cr>
nn <buffer><silent><localleader>f :call defxhelper#search_file()<cr>
nn <buffer><silent><localleader>o :call defxhelper#open_with_app()<cr>
nn <buffer><silent><localleader>e :call defxhelper#show_in_explorer()<cr>
nm <buffer><silent><localleader>y yy

let g:which_key_defx = {
    \ 'name': 'Defx',
    \ 'key': '<localleader>',
    \ 's': 'search_text',
    \ 'f': 'search_file',
    \ 'o': 'open_with_app',
    \ 'e': 'explorer',
    \ 'y': 'copy path (yy)',
\ }

call which_key#register('defx', 'g:which_key_defx')
nn <buffer><silent><localleader> :WhichKey 'defx'<cr>
```

有了这个功能，我可以在markdown的buffer中配置：
```vim
let maplocalleader = ','

let g:which_key_mkd = {
    \ 'name': 'Markdown',
    \ 'key': '<localleader>',
\ }

call which_key#register('mkd', 'g:which_key_mkd')
nn <buffer><silent><localleader> :WhichKey 'mkd'<cr>
```