### PR TITLE
Fix README command spell

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Plug 'liuchengxu/vim-which-key'
 Plug 'liuchengxu/vim-which-key', { 'on': ['WhichKey', 'WhichKey!'] }
 " To register the descriptions when using the on-demand load feature, use the autocmd hook to call which#register(),
 " e.g., register for the Space key(see more configuration details in the following sections):
-" autocmd! User vim-which-key call which#register('<Space>', 'g:which_key_map')
+" autocmd! User vim-which-key call which_key#register('<Space>', 'g:which_key_map')
 ```
 
 For other plugin managers please refer to their document for more details.


### PR DESCRIPTION
vim-plug on-demand which_key#register wrong spell, missing _key