### PR TITLE
Fix WhichKey! with dictionary argument.

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -11,15 +11,16 @@ endfunction
 function! which_key#start(vis, bang, prefix) " {{{
   let s:vis = a:vis ? 'gv' : ''
   let s:count = v:count != 0 ? v:count : ''
-
-  let key = a:prefix
-  let s:which_key_trigger = key ==# ' ' ? 'SPC' : key
+  let s:which_key_trigger = ''
 
   if a:bang
     let s:runtime = a:prefix
     call which_key#window#open(s:runtime)
     return
   endif
+
+  let key = a:prefix
+  let s:which_key_trigger = key ==# ' ' ? 'SPC' : key
 
   if !has_key(s:cache, key) || g:which_key_run_map_on_popup
     " First run


### PR DESCRIPTION
`:WhichKey! g:which_key_map` doesn't seem to be working.

I'm getting error on nvim 0.4:
`E735: Can only compare Dictionary with Dictionary`
`E15: Invalid expression: key ==# ' ' ? 'SPC' : key`
and then another error:
`E121: Undefined variable: s:which_key_trigger`