### PR TITLE
Allow user provided key symbols

### DIFF
--- a/autoload/which_key/view.vim
+++ b/autoload/which_key/view.vim
@@ -1,5 +1,5 @@
 let s:TYPE = g:which_key#util#TYPE
-let s:displaynames = {
+let s:default_displaynames = {
       \ ' ': 'SPC',
       \ '<C-H>': 'BS',
       \ '<C-I>': 'TAB',
@@ -13,12 +13,21 @@ function! which_key#view#prepare(runtime) abort
   return [layout, rows]
 endfunction
 
+function! which_key#view#get_displaynames()
+  if exists('g:which_key_display_names')
+    return g:which_key_display_names
+  else
+    return s:default_displaynames
+  endif
+endfunction
+
 function! s:calc_layout(mappings) abort " {{{
   let layout = {}
   let smap = filter(copy(a:mappings), 'v:key !=# "name" && !(type(v:val) == s:TYPE.list && v:val[1] == "which_key_ignore")')
   let layout.n_items = len(smap)
+  let displaynames = which_key#view#get_displaynames()
   let length = values(map(smap,
-        \ 'strdisplaywidth(get(s:displaynames, toupper(v:key), v:key).'.
+        \ 'strdisplaywidth(get(displaynames, toupper(v:key), v:key).'.
         \ '(type(v:val) == s:TYPE.dict ? get(v:val, "name", "") : v:val[1]))'))
 
   let maxlength = max(length) + g:which_key_hspace
@@ -55,10 +64,11 @@ function! s:create_rows(layout, mappings) abort
   let col = 0
   let smap = sort(filter(keys(mappings), 'v:val !=# "name"'),'1')
 
+  let displaynames = which_key#view#get_displaynames()
   if get(g:, 'which_key_align_by_seperator', 1)
     let key_max_len = 0
     for k in smap
-      let key = get(s:displaynames, toupper(k), k)
+      let key = get(displaynames, toupper(k), k)
       let width = strdisplaywidth(key)
       if width > key_max_len
         let key_max_len = width
@@ -67,7 +77,7 @@ function! s:create_rows(layout, mappings) abort
   endif
 
   for k in smap
-    let key = get(s:displaynames, toupper(k), k)
+    let key = get(displaynames, toupper(k), k)
     let desc = type(mappings[k]) == s:TYPE.dict ? get(mappings[k], "name", "") : mappings[k][1]
     if desc == 'which_key_ignore'
       continue

--- a/doc/vim-which-key.txt
+++ b/doc/vim-which-key.txt
@@ -295,7 +295,7 @@ If you wish to hide a mapping from the menu set its description to
 >
                                             *g:which_key_display_names*
 Type: |Dict|
-Default: `undefined`
+Default: `{ ' ': 'SPC', '<C-H>': 'BS', '<C-I>': 'TAB', '<TAB>': 'TAB', }`
 
 Override the default symbols used for mappings. Dict keys should be all
 uppercase.

--- a/doc/vim-which-key.txt
+++ b/doc/vim-which-key.txt
@@ -292,7 +292,16 @@ If you wish to hide a mapping from the menu set its description to
 >
     nnoremap <leader>1 :1wincmd w<CR>
     let g:which_key_map.1 = 'which_key_ignore'
+>
+                                            *g:which_key_display_names*
+Type: |Dict|
+Default: `undefined`
 
+Override the default symbols used for mappings. Dict keys should be all
+uppercase.
+>
+    let g:which_key_display_names = {'<CR>': '↵', '<TAB>': '⇆'}
+<
 ==============================================================================
 COMMANDS                                              *vim-which-key-commands*
 


### PR DESCRIPTION
This will allow the user to define their own symbols. For example
```
let g:which_key_display_names = {
      \ ' '         : '□'      ,
      \ '<CR>'      : '↵'      ,
      \ '<BS>'      : '⌫'      ,
      \ '<TAB>'     : '⇆'      ,
      \ '<C-SPACE>' : 'Ctrl-□' ,
      \ }
```
would give something like this
![image](https://user-images.githubusercontent.com/18661557/65782083-389c2780-e14d-11e9-8f0a-dc7772f8fef3.png)
