### PR TITLE
Fix syntax regex for longer key symbols

### DIFF
--- a/syntax/which_key.vim
+++ b/syntax/which_key.vim
@@ -6,7 +6,7 @@ let b:current_syntax = 'which_key'
 let s:sep = which_key#util#get_sep()
 
 execute 'syntax match WhichKeySeperator' '/'.s:sep.'/' 'contained'
-execute 'syntax match WhichKey' '/[^\s].\{1,3}'.s:sep.'/' 'contains=WhichKeySeperator'
+execute 'syntax match WhichKey' '/\(^\s*\|\s\{2,}\)\S.\{-}'.s:sep.'/' 'contains=WhichKeySeperator'
 syntax match WhichKeyGroup / +[0-9A-Za-z_/-]*/
 syntax region WhichKeyDesc start="^" end="$" contains=WhichKey, WhichKeyGroup, WhichKeySeperator
 


### PR DESCRIPTION
Fixes the syntax highlighting for key symbols longer than 3 characters.

Old
![image](https://user-images.githubusercontent.com/18661557/65811975-d715a080-e1c0-11e9-8576-887630e1cef6.png)  
![image](https://user-images.githubusercontent.com/18661557/65811981-00363100-e1c1-11e9-904d-d800a890aca2.png)

New
![image](https://user-images.githubusercontent.com/18661557/65812001-43909f80-e1c1-11e9-96d2-d21ae03cb5fe.png)  
![image](https://user-images.githubusercontent.com/18661557/65811991-2eb40c00-e1c1-11e9-9f41-c2035590286f.png)
