### PR TITLE
Add support for special characters

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -225,23 +225,11 @@ function! s:getchar() abort
     return ''
   endif
 
-  if type(c) == s:TYPE.number
-    " <Tab>, <C-I> = 9
-    let input .= c == 9 ? '<Tab>' : nr2char(c)
-  else
-    " Special characters
-    let input .= g:which_key#util#special_keys[c]
-  endif
-
+  let input .= which_key#util#parse_getchar(c)
   if s:has_children(input)
     while 1
       if !s:wait_with_timeout(g:which_key_timeout)
-        let c = getchar()
-        if type(c) == s:TYPE.number
-          let input .= c == 9 ? '<Tab>' : nr2char(c)
-        else
-          let input .= g:which_key#util#special_keys[c]
-        endif
+        let input .= which_key#util#parse_getchar(getchar())
       else
         break
       endif

--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -225,14 +225,23 @@ function! s:getchar() abort
     return ''
   endif
 
-  " <Tab>, <C-I> = 9
-  let input .= c == 9 ? '<Tab>' : nr2char(c)
+  if type(c) == s:TYPE.number
+    " <Tab>, <C-I> = 9
+    let input .= c == 9 ? '<Tab>' : nr2char(c)
+  else
+    " Special characters
+    let input .= g:which_key#util#special_keys[c]
+  endif
 
   if s:has_children(input)
     while 1
       if !s:wait_with_timeout(g:which_key_timeout)
         let c = getchar()
-        let input .= c == 9 ? '<Tab>' : nr2char(c)
+        if type(c) == s:TYPE.number
+          let input .= c == 9 ? '<Tab>' : nr2char(c)
+        else
+          let input .= g:which_key#util#special_keys[c]
+        endif
       else
         break
       endif

--- a/autoload/which_key/util.vim
+++ b/autoload/which_key/util.vim
@@ -78,3 +78,26 @@ function! which_key#util#format(mapping) abort
   " let l:ret = substitute(l:ret, '^<Plug>', '', '')
   return l:ret
 endfunction
+
+function! s:m_char(char)
+  if a:char == '"'
+    return ["<M-\">", "\<M-\">"]
+  endif
+  let m_char = '<M-' . a:char . '>'
+  let m_char_code = eval('"\' . m_char . '"')
+  return [m_char, m_char_code]
+endfunction
+
+function! s:to_list(str)
+  return split(a:str, '\zs')
+endfunction
+
+
+let s:chars = s:to_list('AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789')
+      \ + s:to_list('`~!@#$%^&*()-_=+')+ s:to_list(' 	') + s:to_list('[]{};:''"\|,./<>?')
+
+let g:which_key#util#special_keys = {"\<C-Space>": "<C-Space>"}
+for c in s:chars
+  let [key, code] = s:m_char(c)
+  let g:which_key#util#special_keys[code] = key
+endfor

--- a/autoload/which_key/util.vim
+++ b/autoload/which_key/util.vim
@@ -101,3 +101,13 @@ for c in s:chars
   let [key, code] = s:m_char(c)
   let g:which_key#util#special_keys[code] = key
 endfor
+
+function! which_key#util#parse_getchar(input)
+  if type(a:input) == g:which_key#util#TYPE.number
+    " <Tab>, <C-I> = 9
+    return a:input == 9 ? '<Tab>' : nr2char(a:input)
+  else
+    " Special characters
+    return g:which_key#util#special_keys[a:input]
+  endif
+endfunction

--- a/autoload/which_key/util.vim
+++ b/autoload/which_key/util.vim
@@ -88,14 +88,7 @@ function! s:m_char(char)
   return [m_char, m_char_code]
 endfunction
 
-function! s:to_list(str)
-  return split(a:str, '\zs')
-endfunction
-
-
-let s:chars = s:to_list('AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789')
-      \ + s:to_list('`~!@#$%^&*()-_=+')+ s:to_list(' 	') + s:to_list('[]{};:''"\|,./<>?')
-
+let s:chars = map(range(32, 126), 'nr2char(v:val)')
 let g:which_key#util#special_keys = {"\<C-Space>": "<C-Space>"}
 for c in s:chars
   let [key, code] = s:m_char(c)


### PR DESCRIPTION
Support Alt mappings, as well as Ctrl+Space. getchar returns a string of the input in that case, instead of a character number, so nr2char doesn't work for them.
My solution doesn't support all possible inputs (for example inputs with accents <M-à>, etc), but this should be good enough for most people.