### PR TITLE
change mpd.lhs for vim8.1.2168+

### DIFF
--- a/autoload/which_key/map.vim
+++ b/autoload/which_key/map.vim
@@ -44,6 +44,7 @@ function! which_key#map#parse(key, dict, visual) " {{{
       if (visual && match(mapd.mode, "[vx ]") >= 0) ||
             \ (!visual && match(mapd.mode, "[vx]") == -1)
         let mapd.lhs = which_key#util#string_to_keys(mapd.lhs)
+        let mapd.lhs = [mapd.lhs[-1]]
         call s:add_map_to_dict(mapd, 0, a:dict)
       endif
     endif


### PR DESCRIPTION
Just as I have mentioned in #85 , 
The cause of the bug may be the the update of internal function of vim `substitute`, in 
[map.vim/which_key#map#parse](https://github.com/liuchengxu/vim-which-key/blob/master/autoload/which_key/map.vim)
The new donot subsitute specific key `<M->` to ` `, and `mpd.lhs` value finally return to be a list of length 2, and the second is the one wanted. 
So I just add one line, it worked with vim-8.1.2168+