### PR TITLE
Disable foldenable option for the hint buffer.

### DIFF
--- a/ftplugin/which_key.vim
+++ b/ftplugin/which_key.vim
@@ -5,6 +5,7 @@ setlocal
   \ norelativenumber
   \ nolist
   \ nowrap
+  \ nofoldenable
   \ nopaste
   \ nomodeline
   \ noswapfile


### PR DESCRIPTION
Sometimes other plugins would like to parse keybindings as folds, such as the following image.
![2020-08-05-162005_scrot_1920x913](https://user-images.githubusercontent.com/8148386/89431348-b8186100-d737-11ea-9202-73b5ff665eee.png)

This patch avoids these folds.
