### PR TITLE
Support passing a dict ref to `which_key#register()`

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -98,7 +98,11 @@ endfunction
 function! s:create_runtime(key)
   let key = a:key
   if has_key(s:desc, key)
-    let runtime = deepcopy({s:desc[key]})
+    if type(s:desc[key]) == s:TYPE.dict
+      let runtime = deepcopy(s:desc[key])
+    else
+      let runtime = deepcopy({s:desc[key]})
+    endif
     let native = s:cache[key]
     call s:merge(runtime, native)
   else


### PR DESCRIPTION
This allows more arbitrary mappings, not limited by the supported values of `{ 'g:somedict' }` (e.g. local dicts, subkeys, etc.)

```vim
let s:mydict = { 'some': {} }
call which_key#register('<Space>', s:mydict.some)
```