### PR TITLE
Sort groups keys to the end

### DIFF
--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -92,7 +92,18 @@ function! s:create_rows(layout, mappings) abort
   let rows = []
   let row = 0
   let col = 0
-  let smap = sort(filter(keys(mappings), 'v:val !=# "name"'), 'i')
+
+  let leaf_keys = []
+  let dict_keys = []
+  for key in sort(filter(keys(mappings), 'v:val !=# "name"'), 'i')
+    if type(mappings[key]) == s:TYPE.dict
+      call add(dict_keys, key)
+    else
+      call add(leaf_keys, key)
+    endif
+  endfor
+
+  let smap = leaf_keys + dict_keys
 
   let displaynames = which_key#renderer#get_displaynames()
   if get(g:, 'which_key_align_by_seperator', 1)


### PR DESCRIPTION
This is the default in both spacemacs and doom emacs, which feels quite a bit more intuitive. If you don't want to break existing users' expectation, making it configurable should be trivial too.