### PR TITLE
Fix the padding size of centered opt when relative win opt is on

### DIFF
--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -173,10 +173,21 @@ function! s:create_rows(layout, mappings) abort
 
   " Doesnt work in vertical
   if g:which_key_centered && !g:which_key_vertical
+    if !exists('s:center_offset')
+      let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
+      let line_number_size = &number ? len(string(line('$'))) : 0
+      let s:center_offset = sign_column_size + line_number_size
+    endif
+    let display_cap = g:which_key_floating_relative_win ? winwidth(g:which_key_origin_winid) : &columns
+    let max_display_size = display_cap - s:center_offset
+    let left_padding_size = float2nr(floor((max_display_size - row_max_size) / 2))
+
+    " let left_padding_size = (&columns - row_max_size) / 2
     for row in range(len(rows))
-      let rows[row][0] = repeat(" ", (&columns - row_max_size) / 2)
+      let rows[row][0] = repeat(' ', left_padding_size)
     endfor
   endif
+  echom string(rows)
   call map(rows, 'join(v:val, "")')
 
   return rows
@@ -198,3 +209,23 @@ function! s:escape_keys(inp) abort " {{{
   let l:ret = substitute(l:ret, '|', '<Bar>', '')
   return l:ret
 endfunction " }}}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -176,18 +176,17 @@ function! s:create_rows(layout, mappings) abort
     if !exists('s:center_offset')
       let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
       let line_number_size = &number ? len(string(line('$'))) : 0
-      let s:center_offset = sign_column_size + line_number_size
+      let s:centered_offset = sign_column_size + line_number_size
     endif
+
     let display_cap = g:which_key_floating_relative_win ? winwidth(g:which_key_origin_winid) : &columns
-    let max_display_size = display_cap - s:center_offset
+    let max_display_size = display_cap - s:centered_offset
     let left_padding_size = float2nr(floor((max_display_size - row_max_size) / 2))
 
-    " let left_padding_size = (&columns - row_max_size) / 2
     for row in range(len(rows))
       let rows[row][0] = repeat(' ', left_padding_size)
     endfor
   endif
-  echom string(rows)
   call map(rows, 'join(v:val, "")')
 
   return rows
@@ -209,23 +208,3 @@ function! s:escape_keys(inp) abort " {{{
   let l:ret = substitute(l:ret, '|', '<Bar>', '')
   return l:ret
 endfunction " }}}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -173,14 +173,13 @@ function! s:create_rows(layout, mappings) abort
 
   " Doesnt work in vertical
   if g:which_key_centered && !g:which_key_vertical
-    if !exists('s:center_offset')
-      let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
-      let line_number_size = &number ? len(string(line('$'))) : 0
-      let s:centered_offset = sign_column_size + line_number_size
-    endif
+    let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
+    let line_number_size = &number ? len(string(line('$'))) : 0
+    let centered_offset = sign_column_size + line_number_size
 
     let display_cap = g:which_key_floating_relative_win ? winwidth(g:which_key_origin_winid) : &columns
-    let max_display_size = display_cap - s:centered_offset
+    let max_display_size = display_cap - centered_offset
+
     let left_padding_size = float2nr(floor((max_display_size - row_max_size) / 2))
 
     for row in range(len(rows))


### PR DESCRIPTION
Before:

<img width="1680" alt="截屏2021-04-04 上午10 19 01" src="https://user-images.githubusercontent.com/8850248/113496784-aa69e400-952f-11eb-85bd-724b811d39a5.png">

After:

<img width="1680" alt="截屏2021-04-04 上午10 19 20" src="https://user-images.githubusercontent.com/8850248/113496789-b35ab580-952f-11eb-8863-d60f259900a2.png">


CC @BrotifyPacha 
