### PR TITLE
Set modifiable buffer option before setting lines for nvim floating windows

### DIFF
--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -101,7 +101,7 @@ function! s:show_floating_win(rows, layout) abort
     let s:bufnr = nvim_create_buf(v:false, v:false)
   endif
 
-  set modifiable
+  call setbufvar(s:bufnr, '&modifiable', 1)
 
   silent call nvim_buf_set_lines(s:bufnr, 0, -1, 0, rows)
 

--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -101,6 +101,8 @@ function! s:show_floating_win(rows, layout) abort
     let s:bufnr = nvim_create_buf(v:false, v:false)
   endif
 
+  set modifiable
+
   silent call nvim_buf_set_lines(s:bufnr, 0, -1, 0, rows)
 
   let row_offset = &cmdheight + (&laststatus > 0 ? 1 : 0)


### PR DESCRIPTION
Seems to be a bug in Neovim floating windows when location list window is made non modifiable.

``` {.vimscript}
lvimgrep /.*/ %
lopen
set nomodifiable
lclose
```

It is possible to correct that bug by adding a line which let us modify the buffer before adding lines
