### PR TITLE
Fix "." mapping delay

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -173,6 +173,8 @@ function! s:has_children(input) abort
     let group = map(keys(s:runtime), 'v:val =~# "^\'.a:input.'"')
   elseif a:input ==# '"'
     let group = map(keys(s:runtime), "v:val =~# '^".a:input."'")
+  elseif a:input == '.'
+    let group = map(keys(s:runtime), "v:val =~# '^\\.'")
   else
     let group = map(keys(s:runtime), 'v:val =~# "^'.a:input.'"')
   endif


### PR DESCRIPTION
Fixes #177
The delay is caused by a bug in s:has_children(input) function. Where if you would supply "." as the input, it wouldn't be escaped properly. And so it would be interpreted as "any" mapping.
The fix is to add custom elseif for "." case.