### PR TITLE
Set filetype=which_key for floating window as well

### DIFF
--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -102,6 +102,7 @@ function! s:show_floating_win(rows, layout) abort
   endif
 
   call setbufvar(s:bufnr, '&modifiable', 1)
+  call setbufvar(s:bufnr, '&filetype', 'which_key')
 
   silent call nvim_buf_set_lines(s:bufnr, 0, -1, 0, rows)
 


### PR DESCRIPTION
This allow to use if &filetype == 'which_key' regardless of which kind
of window which_key is using.