### PR TITLE
Support Dictionary-function elements within the description dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ See more details about commands and options via `:h vim-which-key`.
 
 See [#178](https://github.com/liuchengxu/vim-which-key/issues/178).
 
+#### How to set keybindings on filetype or other condition?
+
+You may use BufEnter/BufLeave [#132](https://github.com/liuchengxu/vim-which-key/issues/132), a `dictionary-function` [#209](https://github.com/liuchengxu/vim-which-key/pull/209), or *[experimental]* setup per buffer [#48](https://github.com/liuchengxu/vim-which-key/pull/48).
+
 ## Credit
 
 - [vim-leader-guide](https://github.com/hecal3/vim-leader-guide)

--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -115,13 +115,19 @@ function! s:merge(target, native) " {{{
   let target = a:target
   let native = a:native
 
-  for [k, v] in items(target)
+  for [k, V] in items(target)
 
-    if type(v) == s:TYPE.dict && has_key(native, k)
+    " Support a `Dictionary-function` for on-the-fly mappings
+    if type(V) == s:TYPE.funcref
+      " Evaluate the funcref, to allow the result to be processed
+      let target[k] = V()
+    endif
+
+    if type(V) == s:TYPE.dict && has_key(native, k)
 
       if type(native[k]) == s:TYPE.dict
-        if has_key(v, 'name')
-          let native[k].name = v.name
+        if has_key(V, 'name')
+          let native[k].name = V.name
         endif
         call s:merge(target[k], native[k])
       elseif type(native[k]) == s:TYPE.list
@@ -129,17 +135,17 @@ function! s:merge(target, native) " {{{
       endif
 
     " Support add a description to an existing map without dual definition
-    elseif type(v) == s:TYPE.string && k !=# 'name'
+    elseif type(V) == s:TYPE.string && k !=# 'name'
 
       " <Tab> <C-I>
       if k ==# '<Tab>' && has_key(native, '<C-I>')
         let target[k] = [
               \ native['<C-I>'][0],
-              \ v]
+              \ V]
       else
         let target[k] = [
               \ has_key(native, k) ? native[k][0] : 'which_key#error#missing_mapping()',
-              \ v]
+              \ V]
       endif
 
     endif


### PR DESCRIPTION
In writing a C# layer for *space-vim*, I wanted to overlap/replace/augment the '+lsp' key mappings.

**EDIT2:** For example, in *space-vim* the hotkey sequence ' lgd' is '+lsp/+goto/definition' using the existing '+lsp' keymappings using the LSP Client as configured in *space-vim*, but in *.cs files ' lgd' should use *OmniSharp-vim* (in the C# *space-vim* layer) to do the same. *OmniSharp-vim* isn't an LSP Client (it doesn't use the language server protocol (LSP)) but does many of the same things with a *language server*, so it makes sense to use the same hotkeys.

The most convenient way I thought to do this was to use a dictionary-function as an element within the *vim-which-key* description dictionary (see `:help dictionary-function`). May have pros/cons compared to the technique of BufEnter/BufLeave in #132 and perhaps #48.

The dictionary-function can return a different mapping depending on e.g. the `&filetype`.

Example:
```vim
" <space-vim>/layers/+lang/csharp/config.vim

" nickspoons/omnisharp-vim: {
  " A `Dictionary-function` containing vim-which-key mappings
  function! s:SetOmnisharpHotkeysInWhichkey()
    let s:keep_lsp_mapping = get(s:, 'keep_lsp_mapping', deepcopy(g:spacevim#map#leader#desc['l']))

    let l:omnisharp_map = {
    \ 'name': '+omnisharp',
    \ '.': ['<Plug>(omnisharp_code_action_repeat)', 'repeat'],
    \ 'a': ['<Plug>(omnisharp_code_actions)'      , 'code-action'],
    \ 'c': ['<Plug>(omnisharp_global_code_check)' , 'global-code-check'],
    \ 'f': ['<Plug>(omnisharp_code_format)'       , 'formatting'],
    "\ 'h': ['spacevim#lang#util#Hover()'         , 'hover'],
    \ 'h': ['<Plug>(omnisharp_signature_help)'    , 'hover'],
    \ 'H': ['<Plug>(omnisharp_highlight)'         , 'highlight'],
    \ 'r': ['<Plug>(omnisharp_find_usages)'       , 'references'],
    \ 'R': ['<Plug>(omnisharp_rename)'            , 'rename'],
    "\ 's': ['spacevim#lang#util#DocumentSymbol()', 'document-symbol'],
    \ 's': ['<Plug>(omnisharp_documentation)'     , 'document-symbol'],
    "\ 'S': ['spacevim#lang#util#WorkspaceSymbol()', 'workspace-symbol'],
    \ 'S': ['<Plug>(omnisharp_find_symbol)'       , 'workspace-symbol'],
    \ 'g': {
      \ 'name': '+goto',
      \ 'd': ['<Plug>(omnisharp_go_to_definition)', 'definition'],
      \ 't': ['<Plug>(omnisharp_find_type)'       , 'type-definition'],
      \ 'i': ['<Plug>(omnisharp_find_implementations)', 'implementation'],
      \ 's': ['<Plug>(omnisharp_find_symbol)'     , 'symbol'],
      \ },
    \ 'p': {
      \ 'name': '+preview',
      \ 'd': ['<Plug>(omnisharp_preview_definition)'     , 'definition'],
      \ 'i': ['<Plug>(omnisharp_preview_implementations)', 'implementation'],
      \ },
    \ 'b': {
      \ 'name': '+build',
      \ 'p': ['<Plug>(omnisharp_build_project)'      , 'build-project'],
      \ 's': ['<Plug>(omnisharp_build_solution)'     , 'build-solution'],
      \ 'd': ['<Plug>(omnisharp_debug_project)'      , 'debug-project'],
      \ 'v': ['<Plug>(omnisharp_create_debug_config)', 'create-vimspector-config'],
      \ },
    \ }

    if &filetype ==# 'cs'
      return l:omnisharp_map
    else
      return s:keep_lsp_mapping
    endif
  endfunction

  " Integrate OmniSharp hotkeys with vim-which-key
  if spacevim#load('which-key')
    let s:leader = g:spacevim#map#leader#desc
    let s:leader['l'] = function('s:SetOmnisharpHotkeysInWhichkey')
  endif
" }
```

**EDIT:** Very simple changes in vim-which-key. `V` had to be capitalized so as lower-case variable names can't refer to a funcref. And if V was a funcref it had to be called with V() and the result of that dictionary-function assigned to the right location in s:runtime for processing (calculating layout and etc).

**TODO:** I can put a simpler example in the wiki and make a new FAQ entry in the README.md.