### PR TITLE
Add visual mode separate description dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Please note that no matter which mappings and menus you configure, your original
 ### Configuration
 
 - For neovim, [nvim-whichkey-setup.lua](https://github.com/AckslD/nvim-whichkey-setup.lua) provides a wrapper around vim-which-key to simplify configuration in lua.
-  It also solves issues (see #126) when the mapped command is more complex and makes it easy to also map `localleader` and keymaps in visual mode (see #155).
+  It also solves issues (see #126) when the mapped command is more complex and makes it easy to also map `localleader`.
 
 #### Minimal Configuration
 
@@ -184,10 +184,16 @@ You can configure a Dict for each prefix so that the display is more readable.
 To make the guide pop up **Register the description dictionary for the prefix first**. Assuming `Space` is your leader key and the Dict for configuring `Space` is `g:which_key_map`:
 
 ```vim
-call which_key#register('<Space>', "g:which_key_map")
-
 nnoremap <silent> <leader> :<c-u>WhichKey '<Space>'<CR>
 vnoremap <silent> <leader> :<c-u>WhichKeyVisual '<Space>'<CR>
+
+call which_key#register('<Space>', "g:which_key_map")
+```
+
+The above registers the same description dictionary for both normal and visual modes. To use a separate description dictionary for each mode: add a third argument specifying which mode:
+```vim
+call which_key#register('<Space>', "g:which_key_map", 'n')
+call which_key#register('<Space>', "g:which_key_map_visual", 'v')
 ```
 
 The next step is to add items to `g:which_key_map`:

--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -33,7 +33,7 @@ endfunction
 " Parse key-mappings gathered by `:map` and feed them into dict
 function! which_key#mappings#parse(key, dict, visual) " {{{
   let key = a:key ==? ' ' ? '<Space>' : a:key
-  let visual = a:visual
+  let visual = a:visual ==# 'v'
 
   let lines = s:get_raw_map_info(key)
 
@@ -63,8 +63,7 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
     endif
 
     if mapd.lhs !=# '' && mapd.display !~# 'WhichKey.*'
-      if (visual && match(mapd.mode, '[vx ]') >= 0) ||
-            \ (!visual && match(mapd.mode, '[n ]') >= 0)
+      if (match(mapd.mode, visual ? '[vx ]' : '[n ]') >= 0)
         let mapd.lhs = s:string_to_keys(mapd.lhs)
         call s:add_map_to_dict(mapd, 0, a:dict)
       endif

--- a/doc/vim-which-key.txt
+++ b/doc/vim-which-key.txt
@@ -132,6 +132,11 @@ first** (assuming `Space` is your leader key):
   nnoremap <silent> <leader> :<c-u>WhichKey '<Space>'<CR>
   vnoremap <silent> <leader> :<c-u>WhichKeyVisual '<Space>'<CR>
 <
+It is possible to register a separate description dictionary for normal and visual modes:
+>
+  call which_key#register('<Space>', "g:which_key_map", 'n')
+  call which_key#register('<Space>', "g:which_key_map_visual", 'v')
+<
 It is possible to call the guide for keys other than `leader`:
 >
   nnoremap <localleader> :<c-u>WhichKey  ','<CR>
@@ -406,21 +411,30 @@ COMMANDS                                              *vim-which-key-commands*
 ==============================================================================
 FUNCTIONS                                            *vim-which-key-functions*
 
-which_key#register({prefix}, {dict})                    *which_key#register()*
+which_key#register({prefix}, {dict}[, {mode}])          *which_key#register()*
 
   Provide the guide with a {prefix} and its description dictionary. This
   dictionary {dict} is used to provide convenient names for mappings to
   display in the guide popup. Additionally it is used to provide group names.
+  Optionally a separate description dictionary may be provided for each {mode}.
 
-  Possible value: {prefix}: String, {dict}: String
+  Possible value: {prefix}: String, {dict}: String, {mode}: 'n'|'v'
 
   Example:
 >
-    " register dictionary for the <Space>-prefix
+    " register dictionary for the <Space>-prefix in both normal and visual mode
     call which_key#register(' ', "g:space_prefix_dict")
 
-    " register dictionary for the ,-prefix
+    " register dictionary for the ,-prefix in both modes
     call which_key#register(',', "g:comma_prefix_dict")
+
+    " register dictionary for the <Space>-prefix in both normal and visual mode
+    call which_key#register(' ', "g:space_prefix_dict", 'n')
+    call which_key#register(' ', "g:space_prefix_dict", 'v')
+
+    " register separate dictionaries for the <Space>-prefix for each mode
+    call which_key#register(' ', "g:space_prefix_dict_normal", 'n')
+    call which_key#register(' ', "g:space_prefix_dict_visual", 'v')
 <
 
 which_key#start({vis}, {bang}, {prefix})                   *which_key#start()*


### PR DESCRIPTION
Fixes #155.
Explanation and example of use is in my #155 comment.

**EDIT:** It is now backwards compatible with same behaviour.

If end-users want different vim-which-key descriptions in visual mode they'll need to register a description-dictionary for each prefix key and each mode.
```vim
call which_key#register('<Space>', 'g:desc', 'n')
call which_key#register('<Space>', 'g:desc_visual', 'v')
```

If they want the same behaviour as before (one dictionary for both normal and visual modes) they don't have to change anything:
```vim
call which_key#register('<Space>', 'g:desc')
```