### PR TITLE
Allow nesting of description dictionary functions

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -125,10 +125,10 @@ function! s:merge(target, native) " {{{
   for [k, V] in items(target)
 
     " Support a `Dictionary-function` for on-the-fly mappings
-    if type(V) == s:TYPE.funcref
+    while type(target[k]) == s:TYPE.funcref
       " Evaluate the funcref, to allow the result to be processed
-      let target[k] = V()
-    endif
+      let target[k] = target[k]()
+    endwhile
 
     if type(V) == s:TYPE.dict && has_key(native, k)
 


### PR DESCRIPTION
Fixes a bug I noticed when using both vim-lsp and csharp layers in space-vim. They both set a dictionary-function on `g:spacevim#map#leader#desc['l']` resulting in a nesting of functions, but vim-which-key only evaluates the first at present.