### PR TITLE
do not parse mappings with lua implementations

### DIFF
--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -45,6 +45,12 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
   endif
 
   for line in lines
+    " filter out lines like: n  <Space>ca   *@<Lua 129: /opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp/buf.lua:758>
+    " we're not going to get anything useful to display from the rhs of these anyway
+    if line =~? '<Lua '
+      continue
+    endif
+
     let mapd = maparg(split(line[3:])[0], line[0], 0, 1)
     if empty(mapd) || mapd.lhs =~? '<Plug>.*' || mapd.lhs =~? '<SNR>.*'
       continue


### PR DESCRIPTION
i think this is a reasonable compromise, since 1) i think this code is just trying to get the actual mapping so it can show something in the which key menu if the user hasn't supplied a description, 2) there isn't anything useful to display in the case of a Lua implementation, and 3) if we don't ignore these, i'm getting errors like the following in neovim 0.9.0:

```
Error detected while processing function which_key#start[26]..<SNR>35_cache_key[4]..which_key#mappings#parse:
line   25:
E716: Key not present in Dictionary: "rhs])"
E116: Invalid arguments for function call
line   34:
E716: Key not present in Dictionary: "rhs, '<SID>', '<SNR>'.mapd['sid'].'_', 'g')"
E116: Invalid arguments for function substitute
```

thank you for the fantastic plugin. 🙇 