### PR TITLE
1. Comparable with vim7.4. 2. support nvim built-in lua funtion

### DIFF
--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -73,7 +73,7 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
       try
         let sp = split(split(maparg(raw_sp[0], line[0])[:-2])[-1], ":")
         " NOTE: fl is nvim runtime script
-        let fl = sp[0]
+        let fl = expand(sp[0])
         " NOTE: ln is the line where lua function exists
         let ln = str2nr(sp[-1]) - 1
         let rhs = trim(readfile(fl)[ln])

--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -60,17 +60,35 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
   for line in lines
     " filter out lines like: n  <Space>ca   *@<Lua 129: /opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp/buf.lua:758>
     " we're not going to get anything useful to display from the rhs of these anyway
-    if line =~? '<Lua '
-      continue
-    endif
-
-    let mapd = maparg(split(line[3:])[0], line[0], 0, 1)
+    let raw_sp = split(line[3:])
+    let mapd = maparg(raw_sp[0], line[0], 0, 1)
     if empty(mapd) || mapd.lhs =~? '<Plug>.*' || mapd.lhs =~? '<SNR>.*'
       continue
     endif
+    if has_key(mapd, 'desc')
+      let mapd.rhs = mapd.desc
+      unlet mapd.desc
+    elseif has_key(mapd, 'callback')
+      unlet mapd.callback
+      try
+        let sp = split(split(maparg(raw_sp[0], line[0])[:-2])[-1], ":")
+        " NOTE: fl is nvim runtime script
+        let fl = sp[0]
+        " NOTE: ln is the line where lua function exists
+        let ln = str2nr(sp[-1]) - 1
+        let rhs = trim(readfile(fl)[ln])
+        let rhs = split(rhs, 'M.')[1]
+        " create api from file name
+        let api = split(substitute(fl, "\\", "/", 'g'), 'runtime/lua/')[1]
+        let api = substitute(api, 'lua$', '', 'g')
+        let api = substitute(api, '/', '.', 'g')
+        let mapd.rhs = "<Cmd>lua " . api . rhs . '<Cr>'
+      catch /.*/
+        let mapd.rhs = "lua function not show"
+      endtry
+    endif
 
     let mapd.display = call(g:WhichKeyFormatFunc, [mapd.rhs])
-
     let mapd.lhs = substitute(mapd.lhs, key, '', '')
     " FIXME: <Plug>(easymotion-prefix)
     if mapd.lhs ==? '<Space>'

--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -26,8 +26,19 @@ function! s:string_to_keys(input) abort
   endif
 endfunction " }}}
 
+function! s:execute(cmd)
+  if exists("*execute")
+    return execute(a:cmd)
+  else
+    redir => l:output
+    silent! execute a:cmd
+    redir END
+    return l:output
+  endif
+endfunction
+
 function! s:get_raw_map_info(key) abort
-  return split(execute('map '.a:key), "\n")
+  return split(s:execute('map '.a:key), "\n")
 endfunction
 
 " Parse key-mappings gathered by `:map` and feed them into dict
@@ -43,7 +54,9 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
   if key ==# '<Tab>'
     call extend(lines, s:get_raw_map_info('<C-I>'))
   endif
-
+  if !has('nvim') && key[0:2] == '<M-' && !has('patch-8.2.0815')
+    let key = eval('"\' . key . '"')
+  endif
   for line in lines
     " filter out lines like: n  <Space>ca   *@<Lua 129: /opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp/buf.lua:758>
     " we're not going to get anything useful to display from the rhs of these anyway

--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -185,7 +185,7 @@ function! s:create_rows(layout, mappings) abort
 
   " Doesnt work in vertical
   if g:which_key_centered && !g:which_key_vertical
-    let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
+    let sign_column_size = exists('&signcolumn') && &signcolumn ==# 'yes' ? 2 : 0
     let line_number_size = &number ? len(string(line('$'))) : 0
     let centered_offset = sign_column_size + line_number_size
 

--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -51,7 +51,7 @@ function! s:floating_win_col_offset() abort
   if g:which_key_disable_default_offset
     return 0
   else
-    return (&number ? strlen(line('$')) : 0) + (&signcolumn ==# 'yes' ? 2: 0)
+    return (&number ? strlen(line('$')) : 0) + (exists('&signcolumn') && &signcolumn ==# 'yes' ? 2: 0)
   endif
 endfunction
 


### PR DESCRIPTION
1.   Comparable with vim7.4 by adding missing functions when `has('lambda')`, `execute()` not exist
2.  Support nvim builtin-in lua function: The function name is layed in the runtime lua script, and raw.rhs contain the name and the line of the funtion, so it is not hard to parser the function.