### PR TITLE
Comparable with legacy vim, and show nvim lua built funtion

### DIFF
--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -60,15 +60,35 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
     let key = eval('"\' . key . '"')
   endif
   for line in lines
-    " filter out lines like: n  <Space>ca   *@<Lua 129: /opt/homebrew/Cellar/neovim/0.9.0/share/nvim/runtime/lua/vim/lsp/buf.lua:758>
-    " we're not going to get anything useful to display from the rhs of these anyway
-    if line =~? '<Lua '
-      continue
-    endif
-
-    let mapd = maparg(split(line[3:])[0], line[0], 0, 1)
+    let raw_sp = split(line[3:])
+    let mapd = maparg(raw_sp[0], line[0], 0, 1)
     if empty(mapd) || mapd.lhs =~? '<Plug>.*' || mapd.lhs =~? '<SNR>.*'
       continue
+    endif
+    if has_key(mapd, 'desc')
+      let mapd.rhs = mapd.desc
+      unlet mapd.desc
+    " NOTE: nvim's built-in lua functions have `callback` key in mapd, it must be deleted.
+    " Acctually, nvim's runtime script contain these functions, mapd.rhs could be rebuilt
+    " so the built-in lua function could be parsed, maybe it is not a beautiful resolution but workable.
+    elseif has_key(mapd, 'callback')
+      unlet mapd.callback
+      try
+        let sp = split(split(maparg(raw_sp[0], line[0])[:-2])[-1], ":")
+        " `fl` is nvim runtime script
+        let fl = expand(sp[0])
+        " `ln` is the line where the lua function layed,
+        let ln = str2nr(sp[-1]) - 1
+        let rhs = trim(readfile(fl)[ln])
+        let rhs = split(rhs, 'M.')[1]
+        " create api from file name
+        let api = split(substitute(fl, "\\", "/", 'g'), 'runtime/lua/')[1]
+        let api = substitute(api, 'lua$', '', 'g')
+        let api = substitute(api, '/', '.', 'g')
+        let mapd.rhs = "<Cmd>lua " . api . rhs . '<Cr>'
+      catch /.*/
+        let mapd.rhs = "lua function not show"
+      endtry
     endif
 
     let mapd.display = call(g:WhichKeyFormatFunc, [mapd.rhs])

--- a/autoload/which_key/renderer.vim
+++ b/autoload/which_key/renderer.vim
@@ -185,7 +185,7 @@ function! s:create_rows(layout, mappings) abort
 
   " Doesnt work in vertical
   if g:which_key_centered && !g:which_key_vertical
-    let sign_column_size = &signcolumn ==# 'yes' ? 2 : 0
+    let sign_column_size = exists('&signcolumn') && &signcolumn ==# 'yes' ? 2 : 0
     let line_number_size = &number ? len(string(line('$'))) : 0
     let centered_offset = sign_column_size + line_number_size
 

--- a/autoload/which_key/window.vim
+++ b/autoload/which_key/window.vim
@@ -51,7 +51,7 @@ function! s:floating_win_col_offset() abort
   if g:which_key_disable_default_offset
     return 0
   else
-    return (&number ? strlen(line('$')) : 0) + (&signcolumn ==# 'yes' ? 2: 0)
+    return (&number ? strlen(line('$')) : 0) + (exists('&signcolumn') && &signcolumn ==# 'yes' ? 2: 0)
   endif
 endfunction
 


### PR DESCRIPTION
1. Comparable with legacy vim  by adding missing functions when `has('lambda')`, `execute()` not exist
2. Support nvim builtin-in lua function by parse from runtime lua  script.