### PR TITLE
Automatically show <Space> mappings in menu

### DIFF
--- a/autoload/which_key/mappings.vim
+++ b/autoload/which_key/mappings.vim
@@ -94,8 +94,8 @@ function! which_key#mappings#parse(key, dict, visual) " {{{
     let mapd.display = call(g:WhichKeyFormatFunc, [mapd.rhs])
 
     let mapd.lhs = substitute(mapd.lhs, key, '', '')
-    " FIXME: <Plug>(easymotion-prefix)
-    if mapd.lhs ==? '<Space>'
+    " EasyMotion workaround, <leader><leader> is default easymotion prefix
+    if mapd.lhs ==? '<Space>' && mapcheck('<leader><space>', 'n') =~ 'easymotion'
       continue
     endif
     let mapd.lhs = substitute(mapd.lhs, '<Space>', ' ', 'g')


### PR DESCRIPTION
Update workaround for default <leader><leader> EasyMotion prefix to only apply when `<leader><space>` is actually mapped to an EasyMotion action.

This allows other `<leader><space>` mappings to automatically show up in the WhichKey menu, without being explicitly added to the dictionary.

Note: I use `<leader><space>` to toggle showing white space characters

Partial fix for #135 (does not fix `<leader><tab>`, only `<leader><space>`)