### PR TITLE
Fix buffer local maps / option to disable caching

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -141,6 +141,7 @@ function! s:cache_key(mode, key)
   let mode = a:mode
   let key = a:key
   if !has_key(s:cache[mode], key) || g:which_key_run_map_on_popup
+    let s:cache[mode][key] = {}
     call which_key#mappings#parse(key, s:cache[mode], mode)
   endif
 endfunction


### PR DESCRIPTION
Restore code to clear cached keys when g:which_key_run_map_on_popup = 1

This appears to have been accidentally deleted in commit 654dfc15

Fixes #242