### PR TITLE
Fix issue when using dictionary function

### DIFF
--- a/autoload/which_key.vim
+++ b/autoload/which_key.vim
@@ -186,6 +186,7 @@ function! s:merge(target, native) " {{{
     while type(target[k]) == s:TYPE.funcref
       " Evaluate the funcref, to allow the result to be processed
       let target[k] = target[k]()
+      let V = target[k]
     endwhile
 
     if type(V) == s:TYPE.dict


### PR DESCRIPTION
Previously, after the function was evaluated, the rest of the loop merging the dicts containing the descriptions continued using V instead of the return value of the function.

That could probably cause multiple issues, but the one guaranteed issue was when the returned dictionary contained only plain descriptions and no function (plain string instead of list).

If you are using a dictionary function and see
single-letter-descriptions where the letter is the second letter of the description, this probably fixes it.

I'm using this fix myself, but I'm open to other ways of solving this issue.